### PR TITLE
Fixed decryption error due to incorrect size shared secret

### DIFF
--- a/engine.go
+++ b/engine.go
@@ -44,6 +44,7 @@ const (
 // | salt (16) | rs (4) | idlen (1) | keyid (idlen) |
 // +-----------+--------+-----------+---------------+
 const (
+	secretSize     = 32
 	saltSize       = 16
 	recordSizeSize = 4
 	idLenSize      = 1
@@ -155,7 +156,9 @@ func (e *Engine) deriveSharedSecret(params OperationalParams, publicKey *ecdsa.P
 	privateKey := e.keyLookupFunc(params.KeyID)
 	x, _ := privateKey.Curve.ScalarMult(publicKey.X, publicKey.Y, privateKey.D.Bytes())
 	// RFC5903 Section 9 states we should only return x.
-	return x.Bytes(), nil
+	result := x.Bytes()
+	result = append(bytes.Repeat([]byte{0}, secretSize-len(result)), result...)
+	return result, nil
 }
 
 func (e *Engine) buildInfo(base string, infoContext []byte) []byte {

--- a/engine.go
+++ b/engine.go
@@ -156,9 +156,9 @@ func (e *Engine) deriveSharedSecret(params OperationalParams, publicKey *ecdsa.P
 	privateKey := e.keyLookupFunc(params.KeyID)
 	x, _ := privateKey.Curve.ScalarMult(publicKey.X, publicKey.Y, privateKey.D.Bytes())
 	// RFC5903 Section 9 states we should only return x.
-	result := x.Bytes()
-	result = append(bytes.Repeat([]byte{0}, secretSize-len(result)), result...)
-	return result, nil
+	secret := make([]byte, secretSize)
+	x.FillBytes(secret)
+	return secret, nil
 }
 
 func (e *Engine) buildInfo(base string, infoContext []byte) []byte {


### PR DESCRIPTION
When calling `privateKey.Curve.ScalarMult`, we get `big.Int` as a result. Sometimes the number is smaller than expected and then calling `x.Bytes()` returns a 31 bytes slice, which leads to decryption failure.

This fixes the problems and adds padding at the beggining of the slice to make sure the slice is always 32 bytes long.